### PR TITLE
Fix activesupport, add debug logging

### DIFF
--- a/lexis_nexis_instant_authenticate.gemspec
+++ b/lexis_nexis_instant_authenticate.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_dependency 'savon', '~> 2.0'
   spec.add_dependency 'gyoku'
+  spec.add_dependency 'activesupport'
 end

--- a/lib/lexis_nexis_instant_authenticate/requests/base.rb
+++ b/lib/lexis_nexis_instant_authenticate/requests/base.rb
@@ -1,4 +1,7 @@
 require 'gyoku'
+require 'active_support'
+require 'active_support/core_ext/object'
+require 'active_support/inflector'
 
 module LexisNexisInstantAuthenticate
   module Services

--- a/lib/lexis_nexis_instant_authenticate/requests/create_quiz.rb
+++ b/lib/lexis_nexis_instant_authenticate/requests/create_quiz.rb
@@ -15,7 +15,8 @@ module LexisNexisInstantAuthenticate
               age: nil_to_string(age),
               gender: nil_to_string(gender),
               ssn: nil_to_string(ssn),
-              address: nil_to_string(address)
+              address: nil_to_string(address),
+              email: nil_to_string(email)
             }
           }
         }
@@ -54,6 +55,9 @@ module LexisNexisInstantAuthenticate
         }
       end
 
+      def email
+        @person[:email]
+      end
 
     end
   end

--- a/lib/lexis_nexis_instant_authenticate/requests/create_quiz.rb
+++ b/lib/lexis_nexis_instant_authenticate/requests/create_quiz.rb
@@ -16,7 +16,8 @@ module LexisNexisInstantAuthenticate
               gender: nil_to_string(gender),
               ssn: nil_to_string(ssn),
               address: nil_to_string(address),
-              email: nil_to_string(email)
+              email: nil_to_string(email),
+              license: nil_to_string(drivers_license)
             }
           }
         }
@@ -59,6 +60,14 @@ module LexisNexisInstantAuthenticate
         @person[:email]
       end
 
+      def drivers_license
+        return "" unless @person[:drivers_license].present?
+        {
+          :@type => 'DRIVERS_LICENSE',
+          license_number: @person[:drivers_license][:number],
+          issuer: @person[:drivers_license][:state]
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
When not used in a Rails context, the `activesupport` gem is explicitly required.

Also adds:
- support for `email` attribute in `create_quiz`
- support for `drivers_license` attribute in `create_quiz`
- verbose logging when `:log_level` is set to `:debug`
